### PR TITLE
Slightly optimize `find` method by doing an unchecked vector access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ keywords = [ "sortedvec", "lookup", "table", "datastructure", "vec" ]
 readme = "readme.md"
 
 [dev-dependencies]
-quickcheck = "0.8"
-quickcheck_macros = "0.8"
-rand = "0.6.5"
+quickcheck = "0.9"
+quickcheck_macros = "0.9"
+rand = { version = "0.7", features=["small_rng"] }

--- a/benches/dna.rs
+++ b/benches/dna.rs
@@ -1,9 +1,9 @@
 #![feature(test)]
 
-extern crate sortedvec;
 extern crate test;
 
 use rand::prelude::*;
+use rand::rngs::SmallRng;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 
@@ -65,23 +65,23 @@ impl Distribution<Primer> for CustomDist {
 
         for i in 0..length {
             let next = match (prev, rng.gen::<u8>()) {
-                (Nucleobase::Adenine, 0  ..=128) => Nucleobase::Adenine,
+                (Nucleobase::Adenine, 0..=128) => Nucleobase::Adenine,
                 (Nucleobase::Adenine, 129..=170) => Nucleobase::Cytosine,
                 (Nucleobase::Adenine, 171..=240) => Nucleobase::Guanine,
                 (Nucleobase::Adenine, 141..=255) => Nucleobase::Thymine,
 
-                (Nucleobase::Cytosine, 0  ..=80)  => Nucleobase::Adenine,
-                (Nucleobase::Cytosine, 80 ..=100) => Nucleobase::Cytosine,
+                (Nucleobase::Cytosine, 0..=80) => Nucleobase::Adenine,
+                (Nucleobase::Cytosine, 80..=100) => Nucleobase::Cytosine,
                 (Nucleobase::Cytosine, 101..=200) => Nucleobase::Guanine,
                 (Nucleobase::Cytosine, 201..=255) => Nucleobase::Thymine,
 
-                (Nucleobase::Guanine, 0  ..=60)  => Nucleobase::Adenine,
-                (Nucleobase::Guanine, 61 ..=80)  => Nucleobase::Cytosine,
-                (Nucleobase::Guanine, 81 ..=180) => Nucleobase::Guanine,
+                (Nucleobase::Guanine, 0..=60) => Nucleobase::Adenine,
+                (Nucleobase::Guanine, 61..=80) => Nucleobase::Cytosine,
+                (Nucleobase::Guanine, 81..=180) => Nucleobase::Guanine,
                 (Nucleobase::Guanine, 181..=255) => Nucleobase::Thymine,
 
-                (Nucleobase::Thymine, 0  ..=30)  => Nucleobase::Adenine,
-                (Nucleobase::Thymine, 31 ..=120) => Nucleobase::Cytosine,
+                (Nucleobase::Thymine, 0..=30) => Nucleobase::Adenine,
+                (Nucleobase::Thymine, 31..=120) => Nucleobase::Cytosine,
                 (Nucleobase::Thymine, 121..=254) => Nucleobase::Guanine,
                 (Nucleobase::Thymine, 255..=255) => Nucleobase::Thymine,
             };
@@ -89,10 +89,7 @@ impl Distribution<Primer> for CustomDist {
             prev = next;
         }
 
-        Primer {
-            length,
-            sequence,
-        }
+        Primer { length, sequence }
     }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ on `Ord` keys that enables quicker lookups than regular `Vec`s (`O(log(n))` vs `
 and is simpler and more memory efficient than hashmaps. It is ideal for small
 lookup tables where insertions and deletions are infrequent.
 
-**Note**: `sortedvec` is still highly experimental and likely to change significantly.
+**Note**: `sortedvec` is still experimental and its interface may change.
 
 ## Example
 
@@ -60,9 +60,10 @@ The table below displays how lookups scale on the standard library's `HashMap`,
 
 ## Change log
 
- - **5.0**:
+ - **0.5.0**:
    * Introduction of the `sortedvec_slicekey!` macro.
+   * Introduction of the `position` method.
    * Resolved key derivation function naming collisions by associating them to the data structure.
      This fixes the key derivation names to `derive_key`. This is a *breaking change*.
- - **4.1**: First public release.
+ - **0.4.1**: First public release.
 


### PR DESCRIPTION
Slightly optimize `find` method by doing an unchecked vector access once its key has been found.

Add a public `position` method on both struct types, which returns the index of an item where either exists or should be inserted.

Updates dependencies and reformats the crate. These should probably have been separate commits.

Addresses https://github.com/marcusklaas/sortedvec/issues/25.